### PR TITLE
Making Price a list

### DIFF
--- a/R/business-search.R
+++ b/R/business-search.R
@@ -105,7 +105,7 @@ business_search <- function(term, location, latitude = NULL, longitude = NULL, r
         name = business$name,
         rating = business$rating,
         review_count = business$review_count,
-        price = business$price,
+        price = list(business$price),
         image_url = business$image_url,
         is_closed = business$is_closed,
         url = business$url,


### PR DESCRIPTION
If you change the `limit` or `offset` arguments in the `business-search` function, an error appears stating: `Error: Column 'price' must be a 1d atomic vector or a list`. By making the resulting `price` column a list, the error is avoided. 